### PR TITLE
Allow Games to Pay Back Funds

### DIFF
--- a/tests/functions/payback.js
+++ b/tests/functions/payback.js
@@ -1,0 +1,65 @@
+const anchor = require("@project-serum/anchor");
+
+const { SystemProgram } = anchor.web3;
+
+async function paybackFunds(program, provider, gameAccount, arcadeAccount) {
+	const potAccountOne = anchor.web3.Keypair.generate();
+	const potAccountTwo = anchor.web3.Keypair.generate();
+	const potAccountThree = anchor.web3.Keypair.generate();
+
+	await program.rpc.paybackFunds({
+		accounts: {
+			playerOnePot: potAccountOne.publicKey,
+			playerTwoPot: potAccountTwo.publicKey,
+			playerThreePot: potAccountThree.publicKey,
+			gameAccount: gameAccount.publicKey,
+			arcadeAccount: arcadeAccount.publicKey,
+			owner: provider.wallet.publicKey,
+			systemProgram: SystemProgram.programId,
+		},
+		signers: [potAccountOne, potAccountTwo, potAccountThree],
+	});
+
+	return { playerOnePotAccount: potAccountOne, playerTwoPotAccount: potAccountTwo, playerThreePotAccount: potAccountThree };
+}
+
+async function cashOutPot(program, winningWallet, potAccount, previousPotAccount) {
+	await program.rpc.cashOutPot({
+		accounts: {
+			gamePotAccount: potAccount.publicKey,
+			previousPotAccount: previousPotAccount.publicKey,
+			winner: winningWallet.publicKey,
+			systemProgram: SystemProgram.programId,
+		},
+		signers: [winningWallet],
+	});
+}
+
+async function cashOutMostRecentPot(program, winningWallet, arcadeAccount, potAccount) {
+	await program.rpc.cashOutMostRecentPot({
+		accounts: {
+			gamePotAccount: potAccount.publicKey,
+			arcadeState: arcadeAccount.publicKey,
+			winner: winningWallet.publicKey,
+			systemProgram: SystemProgram.programId,
+		},
+		signers: [winningWallet],
+	});
+}
+
+async function refillGameFunds(program, provider, gameAccount, lamports) {
+	await program.rpc.refillGameFunds(lamports, {
+		accounts: {
+			gameAccount: gameAccount.publicKey,
+			payer: provider.wallet.publicKey,
+			systemProgram: SystemProgram.programId,
+		}
+	});
+}
+
+module.exports = {
+	paybackFunds,
+	cashOutPot,
+	cashOutMostRecentPot,
+	refillGameFunds,
+};


### PR DESCRIPTION
This PR writes code that allows owners of games to "cash-out" on their games.  When they do this they will receive half of the funds deposited into the game (excluding the minimum needed to make the account rent exempt).  The remaining 50% will then be distributed to the 1st, 2nd, and 3rd place players in the game's leaderboard (4/14, 2/14, 1/14) by placing the amounts due to each player into a game pot that only they can collect.  This will allow game owners to choose when to collect and distribute the funds from their games instead of centralizing the control anywhere.